### PR TITLE
Thonk Ore Loot-Table

### DIFF
--- a/src/main/java/com/thonk/thonkmod/core/init/BlockInit.java
+++ b/src/main/java/com/thonk/thonkmod/core/init/BlockInit.java
@@ -20,5 +20,6 @@ public class BlockInit {
             () -> new Block(AbstractBlock.Properties.of(Material.STONE, MaterialColor.COLOR_GRAY)
                     .strength(12f, 7f) // Hardness and Resistance
                     // Diamond pic or higher, has block sounds affiliated with minecraft:stone
-                    .harvestTool(ToolType.PICKAXE).harvestLevel(3).sound(SoundType.STONE)));
+                    .harvestTool(ToolType.PICKAXE).harvestLevel(3).sound(SoundType.STONE)
+                    .requiresCorrectToolForDrops())); // It needs to be mined with the tooltype specified or it won't drop
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -20,7 +20,7 @@ logoFile="logo.png" #optional
 modId="thonkmod" #mandatory
 
 # The version number of the mod, use ${} variables or just hardcode it. ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
-version="1.2.1" #mandatory
+version="1.2.2" #mandatory
 
  # A display name for the mod
 displayName="Thonk Mod" #mandatory

--- a/src/main/resources/data/thonkmod/loot_tables/blocks/thonk_ore_block.json
+++ b/src/main/resources/data/thonkmod/loot_tables/blocks/thonk_ore_block.json
@@ -1,0 +1,60 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:alternatives",
+          "children": [
+
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "enchantments": [
+                      {
+                        "enchantment": "minecraft:silk_touch",
+                        "levels": {
+                          "min": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "name": "thonkmod:thonk_ore_block"
+            },
+
+            {
+              "type": "minecraft:item",
+              "functions": [
+                {
+                  "function": "minecraft:set_count",
+                  "count": {
+                    "min": 1,
+                    "max": 1,
+                    "type": "minecraft:uniform"
+                  }
+                },
+
+                {
+                  "function": "minecraft:apply_bonus",
+                  "enchantment": "minecraft:fortune",
+                  "formula": "minecraft:uniform_bonus_count",
+                  "parameters": {
+                    "bonusMultiplier": 1
+                  }
+                }
+
+              ],
+              "name": "thonkmod:thonk_item"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Thonk Ore now drops the Thonk item when mined (diamond pickaxe and above). If used with fortune 3 it gives more than one, and with silk touch it will drop the ore itself.